### PR TITLE
Gridsの参照の上下反転と座標が0丁度だった良きの補正

### DIFF
--- a/Reserch-Pathfinding/Assets/Scripts/Morisita/M_TriangleGraph.cs
+++ b/Reserch-Pathfinding/Assets/Scripts/Morisita/M_TriangleGraph.cs
@@ -63,7 +63,9 @@ public class M_TriangleGraph
         MapData mapData = context.MapData;
         Vector2 centroid = triangleData.Centroid;
         //Debug.Log("before:" + centroid.x);
-        var xy= new Vector2Int((int)(Mathf.Round(centroid.x + 0.5f) - 1f), (int)(Mathf.RoundToInt(centroid.y + 0.5f) - 1f));
+//        var xy = new Vector2Int((int)(Mathf.Round(centroid.x + 0.5f) - 1f), (int)(Mathf.RoundToInt(centroid.y + 0.5f) - 1f));
+        var xy = new Vector2Int((int)(Mathf.Floor(centroid.x + 0.000001f)), (int)(Mathf.Floor(centroid.y + 0.000001f)));
+        xy.y = mapData.Height - 1 - xy.y;// è„â∫îΩì]
 
         return xy;
     }


### PR DESCRIPTION
- mapData.Gridsの位置が上下反転して参照するようなのでｙ軸をひっくり返した
- 位置の小数点が0になった時に-1されてしまっていたようなので、修正